### PR TITLE
Create donar_profile_screen.dart

### DIFF
--- a/lib/screens/donar_profile_screen.dart
+++ b/lib/screens/donar_profile_screen.dart
@@ -1,1 +1,8 @@
+import 'package:flutter/material.dart';
 
+class DonorProfileScreen extends StatefulWidget {
+const DonorProfileScreen({super.key});
+
+@override
+_DonorProfilePageState createState() => _DonorProfilePageState();
+}


### PR DESCRIPTION
Created a StatefulWidget named DonorProfileScreen. Added base structure with a corresponding state class (_DonorProfilePageState). Prepared the widget to manage donor profile information and UI states.